### PR TITLE
oauthenticator 17.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b1025d725dc406977299c87fedea2006fcabac3bea9d4e17f690d4dad044923e
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,6 @@ requirements:
     - pip
     - hatchling
     - hatch-requirements-txt
-    - setuptools
-    - wheel
   run:
     - python
     - jsonschema

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "oauthenticator" %}
-{% set version = "17.3.0" %}
+{% set version = "17.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,17 +7,19 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e5d90cb2411fff3dc6fcc1633468233c0e0e0239422c087c7734d1685055b8f3
+  sha256: b1025d725dc406977299c87fedea2006fcabac3bea9d4e17f690d4dad044923e
 
 build:
   number: 1
-  skip: true  # [py<38]
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   host:
     - python
     - pip
+    - hatchling
+    - hatch-requirements-txt
     - setuptools
     - wheel
   run:
@@ -46,13 +48,14 @@ test:
   requires:
     - pip
     - pytest
-    - pytest-tornasync
+    - pytest-asyncio >=1.2
     - pytest-cov
     - requests-mock
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v {{ ignore_tests }} oauthenticator
+    # Match [tool.pytest.ini_options] in upstream pyproject.toml (not shipped under source_files)
+    - pytest -v -o asyncio_mode=auto -o asyncio_default_fixture_loop_scope=function {{ ignore_tests }} oauthenticator
 
 about:
   home: https://github.com/jupyterhub/oauthenticator


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-13282](https://anaconda.atlassian.net/browse/PKG-13282)
- [Upstream repository](https://github.com/jupyterhub/oauthenticator)

### Explanation of changes:

- Bump version number and update dependencies
- Pass test options to match with upstream
- Reset build number


[PKG-13282]: https://anaconda.atlassian.net/browse/PKG-13282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ